### PR TITLE
Fix: Resolve 'jest is not defined' error by migrating to Vitest APIs

### DIFF
--- a/client/src/__tests__/ChatExportGuidance.test.tsx
+++ b/client/src/__tests__/ChatExportGuidance.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import ChatExportGuidanceModal from '../../components/chat-export/guidance-modal';
+import ChatExportGuidanceModal from '@components/chat-export/guidance-modal';
 
 // Mocks will be added in the setupTests.ts file in a later step
 // jest.mock('@/hooks/use-chat-export', () => ({

--- a/client/src/setupTests.ts
+++ b/client/src/setupTests.ts
@@ -1,21 +1,24 @@
 import '@testing-library/jest-dom';
 
-jest.mock('@/hooks/use-chat-export', () => ({
-  useLogChatExportPrompt: jest.fn(() => ({
-    mutateAsync: jest.fn().mockResolvedValue(undefined), // Ensure mutateAsync is a mock function
+vi.mock('@/hooks/use-chat-export', () => ({
+  useLogChatExportPrompt: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue(undefined), // Ensure mutateAsync is a mock function
   })),
-  useSnoozeChatExportPrompt: jest.fn(() => ({
-    mutateAsync: jest.fn().mockResolvedValue(undefined), // Ensure mutateAsync is a mock function
+  useSnoozeChatExportPrompt: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue(undefined), // Ensure mutateAsync is a mock function
   })),
 }));
 
-jest.mock('wouter', () => ({
-  ...jest.requireActual('wouter'), // Import and spread actual module
-  useLocation: jest.fn(() => ['/current-path', jest.fn()]), // Mock useLocation
-}));
+vi.mock('wouter', async () => {
+  const actual = await vi.importActual('wouter');
+  return {
+    ...actual, // Import and spread actual module
+    useLocation: vi.fn(() => ['/current-path', vi.fn()]), // Mock useLocation
+  };
+});
 
-jest.mock('@/hooks/use-toast', () => ({
-  useToast: jest.fn(() => ({
-    toast: jest.fn(),
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: vi.fn(() => ({
+    toast: vi.fn(),
   })),
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "client", "src"),
       "@shared": path.resolve(__dirname, "shared"),
       "@assets": path.resolve(__dirname, "attached_assets"),
+      "@components": path.resolve(__dirname, "client/src/components"),
     },
   },
   root: path.resolve(__dirname, "client"),
@@ -43,6 +44,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     include: ['**/*.test.ts', '**/*.spec.ts', '**/*.test.tsx', '**/*.spec.tsx'],
-    setupFiles: ['./client/src/setupTests.ts'],
+    setupFiles: ['./src/setupTests.ts'],
   },
 });


### PR DESCRIPTION
- Updated `client/src/setupTests.ts` to use `vi.mock` and `vi.fn` instead of Jest globals.
- Corrected `test.setupFiles` path in root `vite.config.ts` to point to the correct location relative to the Vite root.
- Added `@components` alias to root `vite.config.ts` for cleaner imports.
- Updated import path in `client/src/__tests__/ChatExportGuidance.test.tsx` to use the new `@components` alias.
- Ran `npm audit fix` and attempted to remove deprecated transitive dependencies.